### PR TITLE
Fix Passive Authentication check for PH passports

### DIFF
--- a/app/src/main/java/com/tananaev/passportreader/MainActivity.java
+++ b/app/src/main/java/com/tananaev/passportreader/MainActivity.java
@@ -77,6 +77,8 @@ import java.security.cert.CertPathValidator;
 import java.security.cert.CertificateFactory;
 import java.security.cert.PKIXParameters;
 import java.security.cert.X509Certificate;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -426,7 +428,17 @@ public class MainActivity extends AppCompatActivity {
                     CertPathValidator cpv = CertPathValidator.getInstance(CertPathValidator.getDefaultType());
                     cpv.validate(cp, pkixParameters);
 
-                    Signature sign = Signature.getInstance(sodFile.getDigestEncryptionAlgorithm());
+                    String sodDigestEncryptionAlgorithm = sodFile.getDigestEncryptionAlgorithm();
+
+                    if (sodDigestEncryptionAlgorithm.equals("SSAwithRSA/PSS")) {
+                        sodDigestEncryptionAlgorithm = "SHA256withRSA/PSS";
+                    }
+
+                    Signature sign = Signature.getInstance(sodDigestEncryptionAlgorithm);
+                    if (sodDigestEncryptionAlgorithm.equals("SHA256withRSA/PSS")) {
+                        sign.setParameter(new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1));
+                    }
+
                     sign.initVerify(sodFile.getDocSigningCertificate());
                     sign.update(sodFile.getEContent());
                     passiveAuthSuccess = sign.verify(sodFile.getEncryptedDigest());

--- a/app/src/main/java/com/tananaev/passportreader/MainActivity.java
+++ b/app/src/main/java/com/tananaev/passportreader/MainActivity.java
@@ -430,14 +430,14 @@ public class MainActivity extends AppCompatActivity {
 
                     String sodDigestEncryptionAlgorithm = sodFile.getDigestEncryptionAlgorithm();
 
-                    boolean bSSA = false;
+                    boolean isSSA = false;
                     if (sodDigestEncryptionAlgorithm.equals("SSAwithRSA/PSS")) {
                         sodDigestEncryptionAlgorithm = "SHA256withRSA/PSS";
-                        bSSA = true;
+                        isSSA = true;
                     }
 
                     Signature sign = Signature.getInstance(sodDigestEncryptionAlgorithm);
-                    if (bSSA) {
+                    if (isSSA) {
                         sign.setParameter(new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1));
                     }
 

--- a/app/src/main/java/com/tananaev/passportreader/MainActivity.java
+++ b/app/src/main/java/com/tananaev/passportreader/MainActivity.java
@@ -430,12 +430,14 @@ public class MainActivity extends AppCompatActivity {
 
                     String sodDigestEncryptionAlgorithm = sodFile.getDigestEncryptionAlgorithm();
 
+                    boolean bSSA = false;
                     if (sodDigestEncryptionAlgorithm.equals("SSAwithRSA/PSS")) {
                         sodDigestEncryptionAlgorithm = "SHA256withRSA/PSS";
+                        bSSA = true;
                     }
 
                     Signature sign = Signature.getInstance(sodDigestEncryptionAlgorithm);
-                    if (sodDigestEncryptionAlgorithm.equals("SHA256withRSA/PSS")) {
+                    if (bSSA) {
                         sign.setParameter(new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1));
                     }
 


### PR DESCRIPTION
For some reason, it failed `Passive Authentication` check on `PH` passports. Error screenshot here [NoSuchAlgorithmException](https://imgur.com/tO3c8oVl.png)

It also failed on `Chip Authentication` check because passport has no `DG14`. What it has are: 1, 2, 11, 12, 15. This PR is only to deal on the `Passive Authentication` check. 