### PR TITLE
Update MainActivity.java

### DIFF
--- a/app/src/main/java/com/tananaev/passportreader/MainActivity.java
+++ b/app/src/main/java/com/tananaev/passportreader/MainActivity.java
@@ -428,7 +428,7 @@ public class MainActivity extends AppCompatActivity {
                     CertPathValidator cpv = CertPathValidator.getInstance(CertPathValidator.getDefaultType());
                     cpv.validate(cp, pkixParameters);
 
-                    String sodDigestEncryptionAlgorithm = sodFile.getDigestEncryptionAlgorithm();
+                    String sodDigestEncryptionAlgorithm = sodFile.getDocSigningCertificate().getSigAlgName();
 
                     boolean isSSA = false;
                     if (sodDigestEncryptionAlgorithm.equals("SSAwithRSA/PSS")) {


### PR DESCRIPTION
Tested & working on US Passports. getDigestEncryptionAlgorithm() returns RSA not SHA256withRSA likely due to BouncyCastle changes. sodFile.getDocSigningCertificate().getSigAlgName() returns SHA256withRSA.

Might need to be tested on other passports.