### PR TITLE
Fix for #49 to help enable NFC

### DIFF
--- a/app/src/main/java/com/tananaev/passportreader/MainActivity.kt
+++ b/app/src/main/java/com/tananaev/passportreader/MainActivity.kt
@@ -175,7 +175,7 @@ abstract class MainActivity : AppCompatActivity() {
             } else {
                 Toast.makeText(
                     applicationContext,
-                    "Please activate NFC and press Back to return to the application!",
+                    getString(R.string.enable_nfc_toast),
                     Toast.LENGTH_LONG
                 ).show();
                 Thread.sleep(5_000)

--- a/app/src/main/java/com/tananaev/passportreader/MainActivity.kt
+++ b/app/src/main/java/com/tananaev/passportreader/MainActivity.kt
@@ -34,6 +34,7 @@ import android.util.Log
 import android.view.View
 import android.view.WindowManager
 import android.widget.EditText
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.snackbar.Snackbar
 import com.tananaev.passportreader.ImageUtil.decodeImage
@@ -164,11 +165,22 @@ abstract class MainActivity : AppCompatActivity() {
         super.onResume()
         val adapter = NfcAdapter.getDefaultAdapter(this)
         if (adapter != null) {
-            val intent = Intent(applicationContext, this.javaClass)
-            intent.flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
-            val pendingIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_MUTABLE)
-            val filter = arrayOf(arrayOf("android.nfc.tech.IsoDep"))
-            adapter.enableForegroundDispatch(this, pendingIntent, null, filter)
+            if (adapter.isEnabled) {
+                val intent = Intent(applicationContext, this.javaClass)
+                intent.flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+                val pendingIntent =
+                    PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_MUTABLE)
+                val filter = arrayOf(arrayOf("android.nfc.tech.IsoDep"))
+                adapter.enableForegroundDispatch(this, pendingIntent, null, filter)
+            } else {
+                Toast.makeText(
+                    getApplicationContext(),
+                    "Please activate NFC and press Back to return to the application!",
+                    Toast.LENGTH_LONG
+                ).show();
+                Thread.sleep(5_000)
+                startActivity(Intent(android.provider.Settings.ACTION_NFC_SETTINGS));
+            }
         }
         if (passportNumberFromIntent) {
             // When the passport number field is populated from the caller, we hide the

--- a/app/src/main/java/com/tananaev/passportreader/MainActivity.kt
+++ b/app/src/main/java/com/tananaev/passportreader/MainActivity.kt
@@ -174,7 +174,7 @@ abstract class MainActivity : AppCompatActivity() {
                 adapter.enableForegroundDispatch(this, pendingIntent, null, filter)
             } else {
                 Toast.makeText(
-                    getApplicationContext(),
+                    applicationContext,
                     "Please activate NFC and press Back to return to the application!",
                     Toast.LENGTH_LONG
                 ).show();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,4 +22,5 @@
     <string name="pass">Pass</string>
     <string name="failed">Failed</string>
 
+    <string name="enable_nfc_toast">Please activate NFC and press Back to return to the application!</string>
 </resources>


### PR DESCRIPTION
I have tried to fix #49 and it appears to work ok for me on  Galaxy A53 5G (SM-A546B).

This  may not be the best way to add this check and help the user to enable NFC, but this is how far my android app dev skills go... :S

---

This essentially forces the user to enable NFC to even be able to enter
the passport number etc., but you can't really do anything with the app
anyways. So I figured it was better to just forcefully request the user
to enable it?

It shows the help text in a toast message.

---

Please review this  and merge or reject this as you see fit.