### PR TITLE
fix error scenario if user enters lowercase letters in passport number

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -57,6 +57,7 @@
                     android:id="@+id/input_passport_number"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:inputType="textCapCharacters"
                     android:hint="@string/input_passport_number" />
 
             </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
Hi Anton, I found I was getting an error `org.jmrtd.CardServiceProtocolException: BAC failed in
MUTUAL AUTH (SW = 0x6700: WRONG LENGTH) (step: 2)` if I entered my passport as `pa1234567` instead of `PA1234567`, so thought you might consider this quick fix for it.

Regards,
Glenn