### PR TITLE
Add support for DG15 Active Authentication

### DIFF
--- a/app/src/main/java/com/tananaev/passportreader/ResultActivity.kt
+++ b/app/src/main/java/com/tananaev/passportreader/ResultActivity.kt
@@ -31,6 +31,7 @@ class ResultActivity : AppCompatActivity() {
         findViewById<TextView>(R.id.output_nationality).text = intent.getStringExtra(KEY_NATIONALITY)
         findViewById<TextView>(R.id.output_passive_auth).text = intent.getStringExtra(KEY_PASSIVE_AUTH)
         findViewById<TextView>(R.id.output_chip_auth).text = intent.getStringExtra(KEY_CHIP_AUTH)
+        findViewById<TextView>(R.id.output_active_auth).text = intent.getStringExtra(KEY_ACTIVE_AUTH)
         if (intent.hasExtra(KEY_PHOTO)) {
             @Suppress("DEPRECATION")
             findViewById<ImageView>(R.id.view_photo).setImageBitmap(intent.getParcelableExtra(KEY_PHOTO))
@@ -47,5 +48,6 @@ class ResultActivity : AppCompatActivity() {
         const val KEY_PHOTO_BASE64 = "photoBase64"
         const val KEY_PASSIVE_AUTH = "passiveAuth"
         const val KEY_CHIP_AUTH = "chipAuth"
+        const val KEY_ACTIVE_AUTH = "activeAuth"
     }
 }

--- a/app/src/main/res/layout/activity_result.xml
+++ b/app/src/main/res/layout/activity_result.xml
@@ -82,6 +82,12 @@
                     android:text="@string/result_chip_auth"
                     android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
 
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/result_active_auth"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
+
             </LinearLayout>
 
             <LinearLayout
@@ -137,6 +143,13 @@
 
                 <TextView
                     android:id="@+id/output_chip_auth"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
+                    tools:text="No" />
+
+                <TextView
+                    android:id="@+id/output_active_auth"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:textAppearance="@style/TextAppearance.AppCompat.Subhead"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="result_nationality">Nationality</string>
     <string name="result_passive_auth">Passive Authentication</string>
     <string name="result_chip_auth">Chip Authentication</string>
+    <string name="result_active_auth">Active Authentication</string>
 
     <string name="pass">Pass</string>
     <string name="failed">Failed</string>


### PR DESCRIPTION
Some passports do not support CA but AA (eg. Chinese passports #54). This pr introduces support for DG15 Active Authentication.

![image](https://github.com/user-attachments/assets/c93e3414-8997-496e-a763-1be3fbba8aa0)
