### PR TITLE
Modernize Gradle build configuration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,20 +1,18 @@
 plugins {
     id 'com.android.application'
-    id 'kotlin-android'
+    id 'org.jetbrains.kotlin.android'
     id 'com.google.gms.google-services'
     id 'com.google.firebase.crashlytics'
 }
 
 android {
-    compileSdkVersion 36
-    ndkVersion '23.1.7779620'
+    compileSdk 36
     defaultConfig {
         applicationId 'com.tananaev.passportreader'
         minSdkVersion 23
         targetSdkVersion 36
         versionCode 22
         versionName '3.3'
-        multiDexEnabled = true
     }
     namespace 'com.tananaev.passportreader'
 
@@ -46,8 +44,6 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'com.google.android.material:material:1.13.0'
     implementation 'androidx.core:core-ktx:1.17.0'
     implementation 'com.wdullaer:materialdatetimepicker:4.2.3'

--- a/app/src/main/java/com/tananaev/passportreader/MainApplication.kt
+++ b/app/src/main/java/com/tananaev/passportreader/MainApplication.kt
@@ -15,11 +15,11 @@
  */
 package com.tananaev.passportreader
 
-import androidx.multidex.MultiDexApplication
+import android.app.Application
 import org.spongycastle.jce.provider.BouncyCastleProvider
 import java.security.Security
 
-class MainApplication : MultiDexApplication() {
+class MainApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         Security.insertProviderAt(BouncyCastleProvider(), 1)

--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,6 @@
-buildscript {
-    ext.kotlin_version = '2.2.20'
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.android.tools.build:gradle:8.13.0'
-        classpath 'com.google.gms:google-services:4.4.3'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.6'
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+plugins {
+    id 'com.android.application' version '8.13.0' apply false
+    id 'org.jetbrains.kotlin.android' version '2.2.20' apply false
+    id 'com.google.gms.google-services' version '4.4.3' apply false
+    id 'com.google.firebase.crashlytics' version '3.0.6' apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx4096m
-android.enableJetifier=true
 android.useAndroidX=true
-android.nonTransitiveRClass=false
-android.nonFinalResIds=false

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 include ':app'


### PR DESCRIPTION
## Summary
- Switch root \`build.gradle\` to plugin DSL with \`apply false\`
- Move repositories into \`settings.gradle\` (\`pluginManagement\` + \`dependencyResolutionManagement\`)
- Drop multidex entirely — minSdk 23 enables it automatically. \`MainApplication\` now extends \`Application\` and the \`androidx.multidex\` dep is gone
- Use canonical \`org.jetbrains.kotlin.android\` plugin id instead of the legacy \`kotlin-android\` alias
- Drop explicit \`kotlin-stdlib\` dep — the Kotlin plugin auto-adds it
- Drop stale \`ndkVersion '23.1.7779620'\` — no native code in the project
- Normalize \`compileSdkVersion\` → \`compileSdk\` and drop the unnecessary \`=\` on \`multiDexEnabled\`
- Clean up \`gradle.properties\`: drop \`enableJetifier\` and the \`nonTransitiveRClass=false\` / \`nonFinalResIds=false\` overrides that hold back the modern defaults

No dependency version bumps — config modernization only. Java/Kotlin target stays at 17.

## Test plan
- [ ] CI build (\`assembleRegularDebug\`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)