### PR TITLE
Inline versions in libs.versions.toml

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,40 +1,22 @@
-[versions]
-agp = "8.13.0"
-kotlin = "2.2.20"
-googleServices = "4.4.3"
-crashlyticsGradle = "3.0.6"
-material = "1.13.0"
-coreKtx = "1.18.0"
-materialdatetimepicker = "4.2.3"
-jmrtd = "0.7.18"
-scuba = "0.0.18"
-spongycastle = "1.58.0.0"
-jnbis = "1.1.0"
-bcpkixJdk15on = "1.65"
-commonsIo = "2.22.0"
-firebaseBom = "34.3.0"
-playServicesAds = "25.2.0"
-reviewKtx = "2.0.2"
-
 [libraries]
-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
-androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
-materialdatetimepicker = { group = "com.wdullaer", name = "materialdatetimepicker", version.ref = "materialdatetimepicker" }
-jmrtd = { group = "org.jmrtd", name = "jmrtd", version.ref = "jmrtd" }
-scuba-sc-android = { group = "net.sf.scuba", name = "scuba-sc-android", version.ref = "scuba" }
-spongycastle-prov = { group = "com.madgag.spongycastle", name = "prov", version.ref = "spongycastle" }
-jnbis = { group = "com.github.mhshams", name = "jnbis", version.ref = "jnbis" }
+material = "com.google.android.material:material:1.13.0"
+androidx-core-ktx = "androidx.core:core-ktx:1.18.0"
+materialdatetimepicker = "com.wdullaer:materialdatetimepicker:4.2.3"
+jmrtd = "org.jmrtd:jmrtd:0.7.18"
+scuba-sc-android = "net.sf.scuba:scuba-sc-android:0.0.18"
+spongycastle-prov = "com.madgag.spongycastle:prov:1.58.0.0"
+jnbis = "com.github.mhshams:jnbis:1.1.0"
 # do not update
-bcpkix-jdk15on = { group = "org.bouncycastle", name = "bcpkix-jdk15on", version.ref = "bcpkixJdk15on" }
-commons-io = { group = "commons-io", name = "commons-io", version.ref = "commonsIo" }
-firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
-firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
-firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
-play-services-ads = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "playServicesAds" }
-play-review-ktx = { group = "com.google.android.play", name = "review-ktx", version.ref = "reviewKtx" }
+bcpkix-jdk15on = "org.bouncycastle:bcpkix-jdk15on:1.65"
+commons-io = "commons-io:commons-io:2.22.0"
+firebase-bom = "com.google.firebase:firebase-bom:34.3.0"
+firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
+firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
+play-services-ads = "com.google.android.gms:play-services-ads:25.2.0"
+play-review-ktx = "com.google.android.play:review-ktx:2.0.2"
 
 [plugins]
-android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
-firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "crashlyticsGradle" }
+android-application = { id = "com.android.application", version = "8.13.0" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version = "2.2.20" }
+google-services = { id = "com.google.gms.google-services", version = "4.4.3" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version = "3.0.6" }


### PR DESCRIPTION
## Summary
Drop the \`[versions]\` section. Each library and plugin entry now carries its version inline (string shorthand for libraries, \`version = "…"\` for plugins). Every version was referenced exactly once, so the indirection just added noise.

## Test plan
- [ ] CI build (\`assembleRegularDebug\`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)