### PR TITLE
Fix Passive Auth algorithm + use chip-advertised Chip Authentication OID

### DIFF
--- a/app/src/main/java/com/tananaev/passportreader/MainActivity.kt
+++ b/app/src/main/java/com/tananaev/passportreader/MainActivity.kt
@@ -55,6 +55,7 @@ import org.jmrtd.BACKeySpec
 import org.jmrtd.PassportService
 import org.jmrtd.lds.CardAccessFile
 import org.jmrtd.lds.ChipAuthenticationPublicKeyInfo
+import org.jmrtd.lds.ChipAuthenticationInfo
 import org.jmrtd.lds.PACEInfo
 import org.jmrtd.lds.SODFile
 import org.jmrtd.lds.SecurityInfo
@@ -307,16 +308,35 @@ abstract class MainActivity : AppCompatActivity() {
                 dg14Encoded = IOUtils.toByteArray(dg14In)
                 val dg14InByte = ByteArrayInputStream(dg14Encoded)
                 dg14File = DG14File(dg14InByte)
-                val dg14FileSecurityInfo = dg14File.securityInfos
-                for (securityInfo: SecurityInfo in dg14FileSecurityInfo) {
-                    if (securityInfo is ChipAuthenticationPublicKeyInfo) {
+
+                // DG14 may carry ChipAuthenticationInfo (with the actual CA protocol
+                // OID + keyId) alongside ChipAuthenticationPublicKeyInfo (with the
+                // public key + keyId). The previous code hard-coded the CA OID to
+                // ID_CA_ECDH_AES_CBC_CMAC_256, which fails on passports advertising
+                // a different variant (3DES, AES-128/192, etc.). Match the two by
+                // keyId to use the chip's real CA OID, and try each available key.
+                val caInfos: List<ChipAuthenticationInfo> =
+                    dg14File.chipAuthenticationInfos
+                val pkInfos = dg14File.chipAuthenticationPublicKeyInfos
+
+                for (pkInfo in pkInfos) {
+                    try {
+                        val caInfo = caInfos.firstOrNull { info ->
+                            info.keyId == pkInfo.keyId || info.keyId == null
+                        }
+                        val caOID = caInfo?.objectIdentifier
+                            ?: ChipAuthenticationPublicKeyInfo.ID_CA_ECDH_AES_CBC_CMAC_256
+
                         service.doEACCA(
-                            securityInfo.keyId,
-                            ChipAuthenticationPublicKeyInfo.ID_CA_ECDH_AES_CBC_CMAC_256,
-                            securityInfo.objectIdentifier,
-                            securityInfo.subjectPublicKey,
+                            pkInfo.keyId,
+                            caOID,
+                            pkInfo.objectIdentifier,
+                            pkInfo.subjectPublicKey,
                         )
                         chipAuthSucceeded = true
+                        break // secure messaging re-established on success
+                    } catch (e: Exception) {
+                        Log.w(TAG, "CA attempt failed for keyId=${pkInfo.keyId}: $e")
                     }
                 }
             } catch (e: Exception) {
@@ -368,15 +388,25 @@ abstract class MainActivity : AppCompatActivity() {
                     pkixParameters.isRevocationEnabled = false
                     val cpv = CertPathValidator.getInstance(CertPathValidator.getDefaultType())
                     cpv.validate(cp, pkixParameters)
-                    var sodDigestEncryptionAlgorithm = sodFile.docSigningCertificate.sigAlgName
-                    var isSSA = false
-                    if ((sodDigestEncryptionAlgorithm == "SSAwithRSA/PSS")) {
-                        sodDigestEncryptionAlgorithm = "SHA256withRSA/PSS"
-                        isSSA = true
+                    // Source the signature algorithm from the SOD's SignerInfo (the algorithm
+                    // actually used to sign the SOD), NOT from the Document Signer certificate.
+                    // These can differ; using the wrong one yields a false "Failed".
+                    val sodDigestAlgorithm = sodFile.digestAlgorithm
+                    val sodDigestEncryptionAlgorithm = sodFile.digestEncryptionAlgorithm
+                    val isPSS = sodDigestEncryptionAlgorithm.equals("SSAwithRSA/PSS", ignoreCase = true)
+                    val jcaAlgorithm = if (isPSS) {
+                        val h = if (sodDigestAlgorithm.equals("SHA-1", ignoreCase = true)) "SHA1" else "SHA256"
+                        "${h}withRSA/PSS"
+                    } else {
+                        sodDigestEncryptionAlgorithm
                     }
-                    val sign = Signature.getInstance(sodDigestEncryptionAlgorithm)
-                    if (isSSA) {
-                        sign.setParameter(PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1))
+                    val sign = Signature.getInstance(jcaAlgorithm)
+                    if (isPSS) {
+                        val pssDigest = if (sodDigestAlgorithm.equals("SHA-1", ignoreCase = true)) "SHA-1" else "SHA-256"
+                        val saltLen = MessageDigest.getInstance(pssDigest).digestLength
+                        sign.setParameter(
+                            PSSParameterSpec(pssDigest, "MGF1", MGF1ParameterSpec.SHA256, saltLen, 1),
+                        )
                     }
                     sign.initVerify(sodFile.docSigningCertificate)
                     sign.update(sodFile.eContent)

--- a/app/src/main/java/com/tananaev/passportreader/MainActivity.kt
+++ b/app/src/main/java/com/tananaev/passportreader/MainActivity.kt
@@ -55,7 +55,6 @@ import org.jmrtd.BACKeySpec
 import org.jmrtd.PassportService
 import org.jmrtd.lds.CardAccessFile
 import org.jmrtd.lds.ChipAuthenticationPublicKeyInfo
-import org.jmrtd.lds.ChipAuthenticationInfo
 import org.jmrtd.lds.PACEInfo
 import org.jmrtd.lds.SODFile
 import org.jmrtd.lds.SecurityInfo
@@ -309,23 +308,11 @@ abstract class MainActivity : AppCompatActivity() {
                 val dg14InByte = ByteArrayInputStream(dg14Encoded)
                 dg14File = DG14File(dg14InByte)
 
-                // DG14 may carry ChipAuthenticationInfo (with the actual CA protocol
-                // OID + keyId) alongside ChipAuthenticationPublicKeyInfo (with the
-                // public key + keyId). The previous code hard-coded the CA OID to
-                // ID_CA_ECDH_AES_CBC_CMAC_256, which fails on passports advertising
-                // a different variant (3DES, AES-128/192, etc.). Match the two by
-                // keyId to use the chip's real CA OID, and try each available key.
-                val caInfos: List<ChipAuthenticationInfo> =
-                    dg14File.chipAuthenticationInfos
-                val pkInfos = dg14File.chipAuthenticationPublicKeyInfos
-
-                for (pkInfo in pkInfos) {
+                for (pkInfo in dg14File.chipAuthenticationPublicKeyInfos) {
                     try {
-                        val caInfo = caInfos.firstOrNull { info ->
-                            info.keyId == pkInfo.keyId || info.keyId == null
-                        }
-                        val caOID = caInfo?.objectIdentifier
-                            ?: ChipAuthenticationPublicKeyInfo.ID_CA_ECDH_AES_CBC_CMAC_256
+                        val caOID = dg14File.chipAuthenticationInfos.firstOrNull {
+                            it.keyId == pkInfo.keyId || it.keyId == null
+                        }?.objectIdentifier ?: ChipAuthenticationPublicKeyInfo.ID_CA_ECDH_AES_CBC_CMAC_256
 
                         service.doEACCA(
                             pkInfo.keyId,
@@ -334,7 +321,7 @@ abstract class MainActivity : AppCompatActivity() {
                             pkInfo.subjectPublicKey,
                         )
                         chipAuthSucceeded = true
-                        break // secure messaging re-established on success
+                        break
                     } catch (e: Exception) {
                         Log.w(TAG, "CA attempt failed for keyId=${pkInfo.keyId}: $e")
                     }
@@ -388,25 +375,15 @@ abstract class MainActivity : AppCompatActivity() {
                     pkixParameters.isRevocationEnabled = false
                     val cpv = CertPathValidator.getInstance(CertPathValidator.getDefaultType())
                     cpv.validate(cp, pkixParameters)
-                    // Source the signature algorithm from the SOD's SignerInfo (the algorithm
-                    // actually used to sign the SOD), NOT from the Document Signer certificate.
-                    // These can differ; using the wrong one yields a false "Failed".
-                    val sodDigestAlgorithm = sodFile.digestAlgorithm
                     val sodDigestEncryptionAlgorithm = sodFile.digestEncryptionAlgorithm
                     val isPSS = sodDigestEncryptionAlgorithm.equals("SSAwithRSA/PSS", ignoreCase = true)
-                    val jcaAlgorithm = if (isPSS) {
-                        val h = if (sodDigestAlgorithm.equals("SHA-1", ignoreCase = true)) "SHA1" else "SHA256"
-                        "${h}withRSA/PSS"
-                    } else {
-                        sodDigestEncryptionAlgorithm
-                    }
+                    val pssDigest = if (sodFile.digestAlgorithm.equals("SHA-1", ignoreCase = true)) "SHA-1" else "SHA-256"
+                    val jcaAlgorithm = if (isPSS) "${pssDigest.replace("-", "")}withRSA/PSS" else sodDigestEncryptionAlgorithm
                     val sign = Signature.getInstance(jcaAlgorithm)
                     if (isPSS) {
-                        val pssDigest = if (sodDigestAlgorithm.equals("SHA-1", ignoreCase = true)) "SHA-1" else "SHA-256"
+                        val mgf1Digest = if (pssDigest == "SHA-1") MGF1ParameterSpec.SHA1 else MGF1ParameterSpec.SHA256
                         val saltLen = MessageDigest.getInstance(pssDigest).digestLength
-                        sign.setParameter(
-                            PSSParameterSpec(pssDigest, "MGF1", MGF1ParameterSpec.SHA256, saltLen, 1),
-                        )
+                        sign.setParameter(PSSParameterSpec(pssDigest, "MGF1", mgf1Digest, saltLen, 1))
                     }
                     sign.initVerify(sodFile.docSigningCertificate)
                     sign.update(sodFile.eContent)

--- a/app/src/main/java/com/tananaev/passportreader/MainActivity.kt
+++ b/app/src/main/java/com/tananaev/passportreader/MainActivity.kt
@@ -44,6 +44,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.tananaev.passportreader.ImageUtil.decodeImage
 import com.wdullaer.materialdatetimepicker.date.DatePickerDialog
 import net.sf.scuba.smartcards.CardService
+import net.sf.scuba.smartcards.CardServiceException
 import org.apache.commons.io.IOUtils
 import org.bouncycastle.asn1.ASN1InputStream
 import org.bouncycastle.asn1.ASN1Primitive
@@ -322,7 +323,7 @@ abstract class MainActivity : AppCompatActivity() {
                         )
                         chipAuthSucceeded = true
                         break
-                    } catch (e: Exception) {
+                    } catch (e: CardServiceException) {
                         Log.w(TAG, "CA attempt failed for keyId=${pkInfo.keyId}: $e")
                     }
                 }
@@ -377,11 +378,16 @@ abstract class MainActivity : AppCompatActivity() {
                     cpv.validate(cp, pkixParameters)
                     val sodDigestEncryptionAlgorithm = sodFile.digestEncryptionAlgorithm
                     val isPSS = sodDigestEncryptionAlgorithm.equals("SSAwithRSA/PSS", ignoreCase = true)
-                    val pssDigest = if (sodFile.digestAlgorithm.equals("SHA-1", ignoreCase = true)) "SHA-1" else "SHA-256"
-                    val jcaAlgorithm = if (isPSS) "${pssDigest.replace("-", "")}withRSA/PSS" else sodDigestEncryptionAlgorithm
+                    val isSha1 = sodFile.digestAlgorithm.equals("SHA-1", ignoreCase = true)
+                    val jcaAlgorithm = when {
+                        !isPSS -> sodDigestEncryptionAlgorithm
+                        isSha1 -> "SHA1withRSA/PSS"
+                        else -> "SHA256withRSA/PSS"
+                    }
                     val sign = Signature.getInstance(jcaAlgorithm)
                     if (isPSS) {
-                        val mgf1Digest = if (pssDigest == "SHA-1") MGF1ParameterSpec.SHA1 else MGF1ParameterSpec.SHA256
+                        val pssDigest = if (isSha1) "SHA-1" else "SHA-256"
+                        val mgf1Digest = if (isSha1) MGF1ParameterSpec.SHA1 else MGF1ParameterSpec.SHA256
                         val saltLen = MessageDigest.getInstance(pssDigest).digestLength
                         sign.setParameter(PSSParameterSpec(pssDigest, "MGF1", mgf1Digest, saltLen, 1))
                     }


### PR DESCRIPTION
Fixes #51. Related to #54, #39.

## Passive Authentication
Source the signature algorithm from the SOD's SignerInfo (`sodFile.digestEncryptionAlgorithm`) instead of the Document Signer certificate's `sigAlgName`. These can differ; using the wrong one makes `sign.verify()` return false on passports whose SOD is signed with a different algorithm than the DSC (e.g. RSASSA-PSS SODs). Also derive the PSS hash and salt length from the SOD digest algorithm rather than hard-coding SHA-256.

## Chip Authentication
Read the actual CA protocol OID from the `ChipAuthenticationInfo` entries in DG14 (matched to the public key by keyId) instead of hard-coding `ID_CA_ECDH_AES_CBC_CMAC_256`. Passports advertising a different CA variant (3DES, AES-128/192) previously failed because the wrong cipher keys were derived. Also iterate over all available keys and continue on per-key failure.

Tested on a Lithuanian ePassport: both Passive Authentication and Chip Authentication now report Pass (previously both Failed).